### PR TITLE
Adding case where only one child exists

### DIFF
--- a/src/lib/AppleMaps.js
+++ b/src/lib/AppleMaps.js
@@ -60,15 +60,17 @@ class AppleMaps extends Component {
 		const { children } = this.props
 		let checkLongitudeChange, checkLatitudeChange, checkDirectionChange
 		if (typeof children !== 'undefined') {
+			const firstChild = children[0] ? children[0] : children;
+			const prevFirstChild = prevProps.children[0] ? prevProps.children[0] : prevProps.children;
 			checkLongitudeChange =
-				children[0].props.longitude !==
-				prevProps.children[0].props.longitude
+				firstChild.props.longitude !==
+				prevFirstChild.props.longitude
 			checkLatitudeChange =
-				children[0].props.latitude !==
-				prevProps.children[0].props.latitude
+				firstChild.props.latitude !==
+				prevFirstChild.props.latitude
 			checkDirectionChange =
-				children[0].props.direction !==
-				prevProps.children[0].props.direction
+				firstChild.props.direction !==
+				prevFirstChild.props.direction
 		}
 		if (
 			checkLongitudeChange ||


### PR DESCRIPTION
In the case where there was only one child element, it was not returned as an Array with only one element, but just as the Object itself. Therefore it caused a crashing error. 

`TypeError: undefined is not an object (evaluating 'children[ 0 ].props')`

In order to check for that I added two inline checks that check wether the element at the index 0 exists. If not we can assume that there is only one, because we already checked wether it is undefined earlier.