### PR TITLE
Use default props instead of child.type.name to detect Annotation components

### DIFF
--- a/src/lib/Annotation.js
+++ b/src/lib/Annotation.js
@@ -1,11 +1,12 @@
 import React, { Fragment } from 'react'
 
-const Annotation = () => {
+function Annotation() {
 	return <Fragment />
 }
 
 Annotation.defaultProps = {
-	visible: true
+	visible: true,
+	isAnnotation: true
 }
 
 export default Annotation

--- a/src/lib/AppleMaps.js
+++ b/src/lib/AppleMaps.js
@@ -16,12 +16,12 @@ class AppleMaps extends Component {
 		//	Annotations
 		if (children !== undefined && children.length) {
 			children.forEach(child => {
-				if (child.type.name === 'Annotation') {
+				if (child.props.isAnnotation) {
 					this.createAnnotation(child.props)
 				}
 			})
 		} else if (children !== undefined && children.props) {
-			if (children.type.name === 'Annotation') {
+			if (children.props.isAnnotation) {
 				this.createAnnotation(children.props)
 			}
 		}
@@ -29,12 +29,12 @@ class AppleMaps extends Component {
 		//	Image Annotations
 		if (children !== undefined && children.length) {
 			children.forEach(child => {
-				if (child.type.name === 'ImageAnnotation') {
+				if (child.props.isImageAnnotation) {
 					this.createImageAnnotation(child.props)
 				}
 			})
 		} else if (children !== undefined && children.props) {
-			if (children.type.name === 'ImageAnnotation') {
+			if (children.props.isImageAnnotation) {
 				this.createImageAnnotation(children.props)
 			}
 		}

--- a/src/lib/ImageAnnotation.js
+++ b/src/lib/ImageAnnotation.js
@@ -5,7 +5,8 @@ const ImageAnnotation = () => {
 }
 
 ImageAnnotation.defaultProps = {
-	visible: true
+	visible: true,
+	isImageAnnotation: true
 }
 
 export default ImageAnnotation


### PR DESCRIPTION
This fixes https://github.com/tonyduanesmith/react-apple-mapkitjs/issues/6