### PR TITLE
Allow specifying a custom Coordinate Span instead of zoomlevel.

### DIFF
--- a/src/lib/AppleMaps.js
+++ b/src/lib/AppleMaps.js
@@ -179,10 +179,10 @@ class AppleMaps extends Component {
 	}
 
 	setMainCoords() {
-		const { longitude, latitude } = this.props
+		const { longitude, latitude, spanLat, spanLong } = this.props
 		const mainCoords = new mapkit.CoordinateRegion(
 			new mapkit.Coordinate(latitude, longitude),
-			new mapkit.CoordinateSpan(this.zoomLevel(), this.zoomLevel())
+			new mapkit.CoordinateSpan(spanLat ? spanLat : this.zoomLevel(), spanLong ? spanLong : this.zoomLevel())
 		)
 		this.map.region = mainCoords
 	}


### PR DESCRIPTION
Zoomlevel doesn't give enough control for me, so this MR implements the `spanLat` and `spanLong` props on `<AppleMaps/>` to allow specifying a custom Coordinate Span. This allows calculating the center and span manually and providing this to the AppleMaps component to center the map on all coordinates and have them all show up.